### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/build-branch.yml
+++ b/.github/workflows/build-branch.yml
@@ -15,13 +15,13 @@ jobs:
       uses: actions/checkout@v4.2.2
 
     - name: Setup Java
-      uses: actions/setup-java@v4.5.0
+      uses: actions/setup-java@v4.6.0
       with:
         distribution: 'temurin'
         java-version: 23
 
     - name: Setup Gradle
-      uses: gradle/actions/setup-gradle@v4.2.1
+      uses: gradle/actions/setup-gradle@v4.2.2
 
     - name: Build
       run: ./gradlew build

--- a/.github/workflows/build-main.yml
+++ b/.github/workflows/build-main.yml
@@ -11,13 +11,13 @@ jobs:
       uses: actions/checkout@v4.2.2
 
     - name: Setup Java
-      uses: actions/setup-java@v4.5.0
+      uses: actions/setup-java@v4.6.0
       with:
         distribution: 'temurin'
         java-version: 23
 
     - name: Setup Gradle
-      uses: gradle/actions/setup-gradle@v4.2.1
+      uses: gradle/actions/setup-gradle@v4.2.2
 
     - name: Build
       run: ./gradlew build sourcesJar dokkaGeneratePublicationHtml publish

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -23,13 +23,13 @@ jobs:
         fetch-depth: 0
 
     - name: Setup Java
-      uses: actions/setup-java@v4.5.0
+      uses: actions/setup-java@v4.6.0
       with:
         distribution: 'temurin'
         java-version: 23
 
     - name: Setup Gradle
-      uses: gradle/actions/setup-gradle@v4.2.1
+      uses: gradle/actions/setup-gradle@v4.2.2
 
     - name: Build
       env:


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/setup-java](https://github.com/actions/setup-java)** published a new release **[v4.6.0](https://github.com/actions/setup-java/releases/tag/v4.6.0)** on 2024-12-18T03:49:41Z
* **[gradle/actions](https://github.com/gradle/actions)** published a new release **[v4.2.2](https://github.com/gradle/actions/releases/tag/v4.2.2)** on 2024-12-18T01:34:44Z
