### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/build-branch.yml
+++ b/.github/workflows/build-branch.yml
@@ -17,13 +17,13 @@ jobs:
         uses: actions/checkout@v4.2.2
 
       - name: Setup Java
-        uses: actions/setup-java@v4.7.0
+        uses: actions/setup-java@v4.7.1
         with:
           distribution: 'temurin'
           java-version: 23
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4.3.0
+        uses: gradle/actions/setup-gradle@v4.3.1
 
       - name: Build
         run: ./gradlew build

--- a/.github/workflows/build-main.yml
+++ b/.github/workflows/build-main.yml
@@ -14,13 +14,13 @@ jobs:
         uses: actions/checkout@v4.2.2
 
       - name: Setup Java
-        uses: actions/setup-java@v4.7.0
+        uses: actions/setup-java@v4.7.1
         with:
           distribution: 'temurin'
           java-version: 23
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4.3.0
+        uses: gradle/actions/setup-gradle@v4.3.1
 
       - name: Build
         run: ./gradlew build sourcesJar javadocJar publish

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -23,13 +23,13 @@ jobs:
         uses: actions/checkout@v4.2.2
 
       - name: Setup Java
-        uses: actions/setup-java@v4.7.0
+        uses: actions/setup-java@v4.7.1
         with:
           distribution: 'temurin'
           java-version: 23
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4.3.0
+        uses: gradle/actions/setup-gradle@v4.3.1
 
       - name: Build
         env:
@@ -75,7 +75,7 @@ jobs:
         run: ./gradlew -Pversion=$VERSION updateVersionInReadme
 
       - name: Commit README.md pointing to released version
-        uses: stefanzweifel/git-auto-commit-action@v5.1.0
+        uses: stefanzweifel/git-auto-commit-action@v5.2.0
         with:
           commit_message: Dependency version in README.md updated to ${{ env.VERSION }}
           file_pattern: 'README.md'


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/setup-java](https://github.com/actions/setup-java)** published a new release **[v4.7.1](https://github.com/actions/setup-java/releases/tag/v4.7.1)** on 2025-04-09T02:58:20Z
* **[gradle/actions](https://github.com/gradle/actions)** published a new release **[v4.3.1](https://github.com/gradle/actions/releases/tag/v4.3.1)** on 2025-03-25T22:47:24Z
* **[stefanzweifel/git-auto-commit-action](https://github.com/stefanzweifel/git-auto-commit-action)** published a new release **[v5.2.0](https://github.com/stefanzweifel/git-auto-commit-action/releases/tag/v5.2.0)** on 2025-04-19T08:39:42Z
